### PR TITLE
List shuffling, fix DB connection issue & password reset

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -1,17 +1,12 @@
-import knex from './db'
 import { createClient, google, UserInfo } from './google'
 import { UserInputError, InvalidGrantError } from './error'
 import { ConnectGoogle } from './models'
 
-export const emailInUse = async (email: string) =>
-  await knex('users')
-    .where({ email })
-    .first()
-
 export const connectGoogle = async (
   code: string,
   redirect: string,
-  user_id: string = null
+  user_id: string = null,
+  knex
 ): Promise<Partial<ConnectGoogle> & { info: UserInfo }> => {
   try {
     const client = createClient(redirect)
@@ -22,7 +17,9 @@ export const connectGoogle = async (
       .userinfo.get()
 
     const [emailGone, accountGone] = await Promise.all([
-      emailInUse(data.email),
+      knex('users')
+        .where({ email: data.email })
+        .first(),
       knex('connect_google')
         .where({ google_id: data.id })
         .first(),

--- a/src/apollo.ts
+++ b/src/apollo.ts
@@ -39,6 +39,7 @@ export const server = new ApolloServer({
       setHeader(header, value) {
         requests[requestId].responseHeaders[header] = value
       },
+      knex: requests[requestId].knex,
     }
   },
   debug: !!process.env.IS_OFFLINE,

--- a/src/apollo.ts
+++ b/src/apollo.ts
@@ -22,12 +22,12 @@ const schema = makeExecutableSchema({
 export const server = new ApolloServer({
   schema,
   context: ({ event, context }): ResolverCtx => {
-    const { id, role } =
+    const { id, role, sub } =
       authenticate(
         parseCookies(event.headers?.Cookie ?? event.headers?.cookie).auth
       ) ?? {}
     const roles = role?.split('.').map(v => v.trim()) ?? []
-    const user = new AuthUser(id)
+    const user = new AuthUser(id, sub)
     user.groups = roles.length ? roles : ['visitor']
     const requestId = context.awsRequestId
     return {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,7 +2,9 @@ import jwt from 'jsonwebtoken'
 import * as bcrypt from 'bcrypt'
 import { User } from './models'
 
-export function authenticate(token: string): { id: string; role: string } {
+export function authenticate(
+  token: string
+): { id: string; role: string; sub: string } {
   if (!token) return
   try {
     return jwt.verify(token, process.env.PUBLIC_KEY) as any

--- a/src/authorization/groups.ts
+++ b/src/authorization/groups.ts
@@ -118,7 +118,7 @@ export const user: Group = {
       effect: 'allow',
       action: '*',
       resource: 'signin_upframe',
-      where: 'signin_upframe.user_id = current.id',
+      where: 'signin_upframe.email = current.email',
     },
     {
       effect: 'allow',

--- a/src/authorization/user.ts
+++ b/src/authorization/user.ts
@@ -9,7 +9,11 @@ export default class AuthUser {
   private _expanded: Policy[] = []
   public denied: string[] = []
 
-  constructor(public readonly id: string, ...groups: string[]) {
+  constructor(
+    public readonly id: string,
+    public readonly email: string,
+    ...groups: string[]
+  ) {
     this.groups = groups
   }
 
@@ -118,4 +122,4 @@ enum PolicyEffect {
   ALLOW = 1,
 }
 
-export const system = new AuthUser('system', 'admin')
+export const system = new AuthUser('system', undefined, 'admin')

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,4 +1,5 @@
 import knex from 'knex'
+import logger from './logger'
 
 const conn_db = {
   host: process.env.DB_HOST,
@@ -15,8 +16,21 @@ const conn_proxy = {
 
 const connection = process.env.IS_OFFLINE ? conn_db : conn_proxy
 
-export default knex({
-  client: 'pg',
-  connection,
-  acquireConnectionTimeout: 7000,
-})
+export const foo = 'bar'
+
+export default () =>
+  knex({
+    client: 'pg',
+    connection,
+    acquireConnectionTimeout: 7000,
+    pool: {
+      min: 1,
+      max: 1,
+      afterCreate(conn, done) {
+        conn.on('error', error => {
+          logger.error('db connection error', { error })
+        })
+        done()
+      },
+    },
+  })

--- a/src/db.ts
+++ b/src/db.ts
@@ -16,8 +16,6 @@ const conn_proxy = {
 
 const connection = process.env.IS_OFFLINE ? conn_db : conn_proxy
 
-export const foo = 'bar'
-
 export default () =>
   knex({
     client: 'pg',

--- a/src/gcal.ts
+++ b/src/gcal.ts
@@ -4,7 +4,8 @@ import { UserClient, userClient, calendar, upframeClient } from './google'
 export async function addMeetup(
   slot: Slots,
   mentor: User,
-  mentee: User
+  mentee: User,
+  knex: ResolverCtx['knex']
 ): Promise<Partial<Meetup>> {
   const event = {
     id: slot.id.replace(/[^\w]/g, ''),
@@ -51,7 +52,7 @@ export async function addMeetup(
 
   if (mentor.connect_google?.calendar_id) {
     const { data } = await (
-      await userClient(mentor.connect_google)
+      await userClient(knex, mentor.connect_google)
     ).calendar.events.patch({
       calendarId: mentor.connect_google?.calendar_id,
       eventId: event.id,

--- a/src/google.ts
+++ b/src/google.ts
@@ -1,7 +1,6 @@
 import { google, oauth2_v2, calendar_v3 } from 'googleapis'
 import { OAuth2Client } from 'google-auth-library/build/src/auth/oauth2client'
 import { ConnectGoogle } from './models'
-import knex from './db'
 import { GoogleNotConnectedError } from './error'
 import logger from './logger'
 import { filterKeys } from './utils/object'
@@ -68,7 +67,7 @@ export class UserClient {
 
   public client: OAuth2Client
 
-  constructor(userId: string, tokens?: Tokens) {
+  constructor(knex: ResolverCtx['knex'], userId: string, tokens?: Tokens) {
     if (!userId) throw new Error('must provide user id to get client')
     this.user_id = userId
     this.client = createClient()
@@ -105,7 +104,7 @@ export class UserClient {
     )
   }
 
-  public async setAccessToken(access_token) {
+  public async setAccessToken(knex: ResolverCtx['knex'], access_token) {
     console.log('set new access token')
     this.client.setCredentials({ access_token })
     await knex('connect_google')
@@ -122,10 +121,13 @@ export class UserClient {
   }
 }
 
-export const userClient = async (info: Partial<ConnectGoogle>) => {
+export const userClient = async (
+  knex: ResolverCtx['knex'],
+  info: Partial<ConnectGoogle>
+) => {
   return (
     userClients.user_id ??
-    (await new UserClient(info.user_id, info as Tokens).ready)
+    (await new UserClient(knex, info.user_id, info as Tokens).ready)
   )
 }
 

--- a/src/models/list.ts
+++ b/src/models/list.ts
@@ -6,6 +6,8 @@ export class List extends Model {
 
   id!: number
   name!: string
+
+  users?: import('./user').User[]
 }
 
 import('./user').then(

--- a/src/models/mentor.ts
+++ b/src/models/mentor.ts
@@ -9,6 +9,7 @@ export class Mentor extends Model {
   company: string
   headline: string
   slot_reminder_email: string
+  score: number
 
   time_slots?: Slots[]
 

--- a/src/resolvers/fields/calendar.ts
+++ b/src/resolvers/fields/calendar.ts
@@ -11,8 +11,8 @@ const buildDate = (date: string): string => {
 export const name = resolver<string, any>()(({ parent }) => parent.summary)
 
 export const events = resolver<any[], any>()(
-  async ({ parent, args: { max, start } }) => {
-    const client = await userClient(parent)
+  async ({ parent, args: { max, start }, knex }) => {
+    const client = await userClient(knex, parent)
     const { data } = await client.calendar.events.list({
       calendarId: parent.id,
       maxResults: max,

--- a/src/resolvers/fields/mentor.ts
+++ b/src/resolvers/fields/mentor.ts
@@ -55,12 +55,12 @@ export const calendarConnected = resolver<
 )
 
 export const calendars = resolver<any[], User>()(
-  async ({ parent, ctx: { id, setHeader }, args: { ids } }) => {
+  async ({ parent, ctx: { id, setHeader }, args: { ids }, knex }) => {
     if (!parent?.id || id !== parent.id)
       throw new ForbiddenError('not allowed to access calendars')
     if (!parent.connect_google?.calendar_id) return
     try {
-      const client = await userClient(parent.connect_google)
+      const client = await userClient(knex, parent.connect_google)
       if (ids) {
         const res = await Promise.all(
           ids.map(calendarId =>

--- a/src/resolvers/mutations/profile.ts
+++ b/src/resolvers/mutations/profile.ts
@@ -1,4 +1,3 @@
-import knex from '../../db'
 import * as obj from '../../utils/object'
 import { User, UserHandles, UserTags, Tags } from '../../models'
 import _ from 'lodash'
@@ -8,7 +7,8 @@ import { UserInputError } from 'apollo-server-lambda'
 
 const updateSocial = async (
   user: AuthUser,
-  social: { platform: number; handle: string }[]
+  social: { platform: number; handle: string }[],
+  knex: ResolverCtx['knex']
 ) => {
   const [added, removed] = _.partition(social ?? [], ({ handle }) => handle)
   await Promise.all([
@@ -83,9 +83,9 @@ const updateTags = async (
 }
 
 export const updateProfile = resolver<User>()(
-  async ({ args: { input }, ctx: { user }, query }) => {
+  async ({ args: { input }, ctx: { user }, query, knex }) => {
     await Promise.all([
-      updateSocial(user, input.social),
+      updateSocial(user, input.social, knex),
       updateTags(user, input.tags),
     ])
 

--- a/src/resolvers/mutations/tag.ts
+++ b/src/resolvers/mutations/tag.ts
@@ -1,7 +1,6 @@
 import resolver from '../resolver'
 import { UserInputError } from '../../error'
 import { Tags } from '../../models'
-import knex from '../../db'
 
 export const setTagName = resolver<Tags>().isAdmin(
   async ({ query, args: { id, name } }) =>
@@ -10,7 +9,7 @@ export const setTagName = resolver<Tags>().isAdmin(
 )
 
 export const mergeTags = resolver<Tags>().isAdmin(
-  async ({ query, args: { from, into } }) => {
+  async ({ query, knex, args: { from, into } }) => {
     await knex.transaction(async trx => {
       await trx('user_tags')
         .where({ tag_id: from })

--- a/src/resolvers/resolver.ts
+++ b/src/resolvers/resolver.ts
@@ -67,6 +67,7 @@ export default function<M = void, P extends Model = null>() {
             raw: (model?: any) => query.raw(info, ctx, model),
           }
         ) as Query<M extends Model ? M : Model>,
+        knex: ctx.knex,
         parent,
         args,
         ctx,
@@ -80,6 +81,7 @@ export default function<M = void, P extends Model = null>() {
 
 type Resolver<M = void, P = null> = (args: {
   query: Query<M extends Model ? M : Model>
+  knex: ResolverCtx['knex']
   parent: P
   args: any
   ctx: ResolverCtx

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -32,6 +32,7 @@ interface ResolverCtx {
   requestId: string
   clientIp: string
   setHeader(header: string, value: string): void
+  knex: import('knex')
 }
 
 type ModelContent<M extends Model> = {

--- a/src/utils/validity.ts
+++ b/src/utils/validity.ts
@@ -1,11 +1,19 @@
-import * as rules from './validityRules'
+import * as _rules from './validityRules'
+const rules: { [name: string]: _rules.Rule } = _rules
 
-export async function validate(field: string, value: any) {
+export async function validate(
+  field: string,
+  value: any,
+  knex: ResolverCtx['knex']
+) {
   if (!(field in rules)) return `unknown field ${field}`
-  return await rules[field](value)
+  return await rules[field](value, knex)
 }
 
-export async function batchValidate(fields: { [field: string]: any }) {
+export async function batchValidate(
+  fields: { [field: string]: any },
+  knex: ResolverCtx['knex']
+) {
   const format = (v: boolean | string): { valid: boolean; reason?: string } =>
     v === true || v === undefined
       ? { valid: true }
@@ -14,7 +22,7 @@ export async function batchValidate(fields: { [field: string]: any }) {
   return (
     await Promise.all(
       Object.entries(fields).map(([k, v]) =>
-        validate(k, v).then(res => [k, res])
+        validate(k, v, knex).then(res => [k, res])
       ) as Promise<[string, any]>[]
     )
   ).map(([k, v]) => ({ field: k, ...format(v) }))


### PR DESCRIPTION
- sort mentors independently of the exact number of their slots (just considering slots > 0 or not), i.e.:

  rank before: `NumSlots + random{0, 1}`
  rank now: `min{NumSlots, 1} + random{0, 1}`

- shuffle users in lists using the same method

- fix permission issue that prevented non-admins from changing their password

- move database connection management into the handler to scope (hopefully preventing the `connection terminated unexpectedly` issue)
